### PR TITLE
Back-merge release/v0.0.2 Changes to develop

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Articles</h1>
-<h2>v0.0.2</h2>
+<h2>v0.0.2 - 1</h2>
 <ul>
   <% @articles.each do |article| %>
     <li>

--- a/bin/release/prepare_release.sh
+++ b/bin/release/prepare_release.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-if [ -z "$1" ]; then
+if [ -z "$1" ] || [[ ! "$1" =~ ^(major|minor|patch)$ ]]; then
     echo "バージョンをインクリメントするタイプを指定してください。"
     echo "使用可能なオプション: major, minor, patch"
     exit 1
@@ -55,11 +55,6 @@ else
       ;;
     "patch")
       patch=$((patch + 1))
-      ;;
-    *)
-      echo "不正なタイプ: $1"
-      echo "使用可能なオプション: major, minor, patch"
-      exit 1
       ;;
   esac
 

--- a/bin/release/prepare_release.sh
+++ b/bin/release/prepare_release.sh
@@ -15,6 +15,12 @@
 
 set -e
 
+if [ -z "$1" ]; then
+    echo "バージョンをインクリメントするタイプを指定してください。"
+    echo "使用可能なオプション: major, minor, patch"
+    exit 1
+fi
+
 # `gh` コマンドの存在確認
 if ! command -v gh >/dev/null 2>&1; then
     echo "'gh' コマンドが見つかりません。GitHub CLIをインストールしてください。"
@@ -43,7 +49,7 @@ else
       minor=0
       patch=0
       ;;
-    "minor"|"")
+    "minor")
       minor=$((minor + 1))
       patch=0
       ;;
@@ -51,8 +57,8 @@ else
       patch=$((patch + 1))
       ;;
     *)
-      echo "無効な引数: $1"
-      echo "正しい引数: major, minor, patch (省略時: minor)"
+      echo "不正なタイプ: $1"
+      echo "使用可能なオプション: major, minor, patch"
       exit 1
       ;;
   esac


### PR DESCRIPTION
0f44730 - リリースブランチ作成スクリプトで無効な引数のチェックは冒頭で行うようにする (Hideki Akizuki, Sat Sep 9 18:26:59 2023 +0900)
f258bb3 - リリースブランチ作成スクリプトは引数省略不可にする (Hideki Akizuki, Sat Sep 9 18:24:38 2023 +0900)
ade1de8 - test releaseブランチで修正してみる (Hideki Akizuki, Sat Sep 9 18:19:07 2023 +0900)