### PR TITLE
Merge release/v0.0.16 into main

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -142,6 +142,7 @@ jobs:
 
   render-task-definition-and-deploy:
     needs:
+      - build-tag
       - build-and-push-image
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
38a69f8 - Merge pull request #108 from hidekiakizuki/feature/akizuki/bugfix_imamge_tag (Hideki Akizuki, Sat Jul 13 15:32:58 2024 +0900)
55fc2f5 - 生成したtagを取得できない不具合を修正 (Hideki Akizuki, Sat Jul 13 15:30:14 2024 +0900)
5f95f64 - Created new branch feature/akizuki/bugfix_imamge_tag (Hideki Akizuki, Sat Jul 13 15:29:30 2024 +0900)
633c855 - Merge pull request #107 from hidekiakizuki/release/v0.0.15 (Hideki Akizuki, Fri Jul 12 21:34:57 2024 +0900)